### PR TITLE
BASW-733: Ensure that the extension work even when Direct debit extension is not installed

### DIFF
--- a/CRM/Medatahealthchecker/DataChecker/Main.php
+++ b/CRM/Medatahealthchecker/DataChecker/Main.php
@@ -176,7 +176,7 @@ class CRM_Medatahealthchecker_DataChecker_Main {
       'name' => "direct_debit",
     ]);
     if (empty($ddPaymentMethodId['values'][0]['value'])) {
-      return NULL;
+      return 'NULL';
     }
 
     return $ddPaymentMethodId['values'][0]['value'];
@@ -190,7 +190,7 @@ class CRM_Medatahealthchecker_DataChecker_Main {
       'is_test' => 0,
     ]);
     if (empty($ddPaymentProcessorId['values'][0]['id'])) {
-      return NULL;
+      return 'NULL';
     }
 
     return $ddPaymentProcessorId['values'][0]['id'];


### PR DESCRIPTION
## Overview
Fixing an issue where the health checker scheduled job fails when direct debit extension is not installed.

## Before
The scheduled job defined by this extension will fail if direct job extension is not installed, the reason is that there are some queries in it that check for the direct debit payment processor and payment method, and if nothing found then NULL will return, resulting in an syntax error with the query.

e.g:

```
              SELECT cc.id, 'civicrm_contribution', 100, cc.contact_id FROM civicrm_contribution cc
              LEFT JOIN civicrm_value_dd_information cc_mandate ON cc.id = cc_mandate.entity_id
              WHERE cc_mandate.mandate_id IS NULL AND cc.payment_instrument_id = 
              GROUP BY cc.id
```

hence 

```
 AND cc.payment_instrument_id = 
              GROUP BY cc.id
```

## After

I added quotes around the `NULL` that return from getDirectDebitPaymentMethodId() and getDirectDebitPaymentProcessorId(), to make sure the query remain valid even when direct debit extension is installed.

e.g:

```
              SELECT cc.id, 'civicrm_contribution', 100, cc.contact_id FROM civicrm_contribution cc
              LEFT JOIN civicrm_value_dd_information cc_mandate ON cc.id = cc_mandate.entity_id
              WHERE cc_mandate.mandate_id IS NULL AND cc.payment_instrument_id =  NULL
              GROUP BY cc.id
```

hence 

```
 AND cc.payment_instrument_id = NULL
              GROUP BY cc.id

```