### PR TITLE
MAE-738: Add validation for recur contribution cycle day and next contribution date

### DIFF
--- a/CRM/Medatahealthchecker/DataChecker/ErrorCodes.php
+++ b/CRM/Medatahealthchecker/DataChecker/ErrorCodes.php
@@ -24,6 +24,10 @@ class CRM_Medatahealthchecker_DataChecker_ErrorCodes {
 
   const DIRECT_DEBIT_CONTRIBUTIONS_WITH_NO_MANDATES = 1100;
 
+  const RECUR_CONTRIBUTION_WITH_INVALID_CYCLE_DAY = 1200;
+
+  const RECUR_CONTRIBUTION_WITH_INVALID_NEXT_CONTRIB_DATE = 1300;
+
   public static function getAllCodesWithDescription() {
     return [
       self::DD_PAYMENT_METHOD_WITH_NO_PAYMENT_PLAN => 'Contributions paid with Direct Debit but with no related Payment Plan',
@@ -37,6 +41,8 @@ class CRM_Medatahealthchecker_DataChecker_ErrorCodes {
       self::OFFLINE_PAYMENT_PLANS_WITH_NO_SUBSCRIPTION_LINE_ITEMS => 'Offline payment plans but without any subscription line items',
       self::DIRECT_DEBIT_PAYMENT_PLANS_WITH_NO_MANDATES => 'Direct debit payment plans but with no related mandate',
       self::DIRECT_DEBIT_CONTRIBUTIONS_WITH_NO_MANDATES => 'Direct debit contributions but with no related mandate',
+      self::RECUR_CONTRIBUTION_WITH_INVALID_CYCLE_DAY => 'Recurring contributions with invalid cycle day',
+      self::RECUR_CONTRIBUTION_WITH_INVALID_NEXT_CONTRIB_DATE => 'Recurring contributions with invalid next contribution date',
     ];
   }
 


### PR DESCRIPTION
## Overview
This PR adds validation for recur contribution cycle day and next contribution date.

- Where Cycle day >28 AND "frequency_unit" of payment plan: "monthly"
- Where Next contribution date >28th of the month AND "frequency_unit" of payment plan: "monthly"

## Before
The validations do not exist

## After
<img width="1426" alt="Screenshot 2022-06-13 at 10 18 19" src="https://user-images.githubusercontent.com/85277674/173321822-88de04bf-2e84-4d9e-83e3-bfaa50bfe586.png">

