### PR TITLE
CIVIB-78: Validate Manual Direct Debit data only when the extension i…

### DIFF
--- a/CRM/Medatahealthchecker/DataChecker/Main.php
+++ b/CRM/Medatahealthchecker/DataChecker/Main.php
@@ -6,8 +6,6 @@ class CRM_Medatahealthchecker_DataChecker_Main {
 
   public function validateData() {
     $this->emptyDataIssuesTable();
-
-    $this->checkContributionsPaidByDirectDebitButWithoutPaymentPlan();
     $this->checkMissingFinancialTransactionRecordsOnContributions();
     $this->checkMissingLineItemsOnContributions();
     $this->checkMissingFinancialItemRecordsOnLineItems();
@@ -16,10 +14,14 @@ class CRM_Medatahealthchecker_DataChecker_Main {
     $this->checkOfflinePaymentPlansWithNoRelatedMemberships();
     $this->checkOfflinePaymentPlansWithAutoRenewFlagNotTrue();
     $this->checkOfflinePaymentPlansWithNoSubscriptionLineItems();
-    $this->checkDirectDebitPaymentPlansWithNoMandates();
-    $this->checkDirectDebitContributionsWithNoMandates();
     $this->checkRecurringContributionsWithInvalidCycleDay();
     $this->checkRecurringContributionsWithInvalidNextContriburionDate();
+
+    if (CRM_Medatahealthchecker_Utils_ExtensionUtils::isExtensionEnabled('uk.co.compucorp.manualdirectdebit')) {
+      $this->checkContributionsPaidByDirectDebitButWithoutPaymentPlan();
+      $this->checkDirectDebitPaymentPlansWithNoMandates();
+      $this->checkDirectDebitContributionsWithNoMandates();
+    }
   }
 
   private function emptyDataIssuesTable() {

--- a/CRM/Medatahealthchecker/Utils/ExtensionUtils.php
+++ b/CRM/Medatahealthchecker/Utils/ExtensionUtils.php
@@ -1,0 +1,18 @@
+<?php
+
+class CRM_Medatahealthchecker_Utils_ExtensionUtils {
+
+  public static function isExtensionEnabled($extensionName) {
+    $result = civicrm_api3('Extension', 'get', [
+      'sequential' => 1,
+      'full_name' => $extensionName,
+    ]);
+
+    if ($result['count'] === 1 && $result['values'][0]['status'] === 'installed') {
+      return TRUE;
+    }
+
+    return FALSE;
+  }
+
+}


### PR DESCRIPTION
## Overview

This PR adds a logic to validate data only when Manual Direct Debit is extension is enabled.

## Before

Missing table dd_contribution_recurr_mandate_ref error when schedule job was run when the site did not have Manual Direct Debit extension enabled.

## After

Cron job is run without above error when Manual Direct Debit extension enabled. 